### PR TITLE
feature: add support for sqlcipher

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,57 @@ connection closed
 ```
 </details>
 
+## Using SQLCipher instead of vanilla SQLite
+
+This binding can talk to **[SQLCipher](https://github.com/sqlcipher/sqlcipher)** out-of-the-box – you just need to link against `libsqlcipher` (note: this has only been tested on MacOS but should work across platforms):
+
+| What you need | How to do it |
+|---------------|--------------|
+| **1. Install SQLCipher** | macOS: `brew install sqlcipher`  •  Ubuntu: `apt install sqlcipher libsqlcipher-dev`  •  Windows: grab the pre-built DLLs |
+| **2. Tell Odin you want SQLCipher** | `odin build . -define:SQLITE3_USE_SQLCIPHER=true -define:SQLITE3_DYNAMIC_LIB=true -define:SQLITE3_SYSTEM_LIB=true` |
+
+
+### 🔐  SQLCipher-only functions
+
+When `USE_SQLCIPHER` is **true** four extra C symbols become available in the `sqlite` package:
+
+| Odin name            | C symbol             | Purpose |
+|----------------------|----------------------|---------|
+| `sqlite.key`         | `sqlite3_key`        | Apply the *initial* key (password or raw binary) to a newly-opened database connection. |
+| `sqlite.key_v2`      | `sqlite3_key_v2`     | Same as above, but lets you specify the schema name (usually `"main"`). |
+| `sqlite.rekey`       | `sqlite3_rekey`      | Re-encrypt the database with a **new** key. |
+| `sqlite.rekey_v2`    | `sqlite3_rekey_v2`   | Same as above, but scoped to a specific attached schema. |
+
+All four return the usual SQLite result code – `SQLITE_OK` on success, or `SQLITE_NOTADB` / `SQLITE_ERROR` if the key/password is wrong. You can also use the bare `PRAGMA key="mypassword"` and `PRAGMA rekey="newpassword"` if desired.
+
+*If you compile without `-define:SQLITE3_USE_SQLCIPHER=true`, you will not be able to access the new keys, keeping SQLite builds safe and free from unused exports.*
+
+### Minimal example
+
+```odin
+main :: proc() {
+    db: ^sqlite.Connection = nil
+
+    // Open the database file.
+    if sqlite.open("./encrypted.sqlite", &db) != .Ok {
+        panic("open failed")
+    }
+    defer sqlite.close(db_handle)
+
+    // Provide the secret for the database. You MUST do this before using it.
+    secret : cstring = "Tr0ub4dor&3";
+    if sqlite.key(db, cast(rawptr)secret.data, cast(c.int)len(secret)) != .Ok {
+        panic("wrong key?");
+    }
+
+    // Change the secret for the database.
+    new_secret : cstring = "CorrectHorseBatteryStaple";
+    if sqlite.rekey(db, cast(rawptr)new_secret.data, cast(c.int)len(new_secret)) != .Ok {
+        panic("rekey failed");
+    }
+}
+```
+
 ---
 
 ## Contributions

--- a/README.md
+++ b/README.md
@@ -236,11 +236,11 @@ connection closed
 
 This binding can talk to **[SQLCipher](https://github.com/sqlcipher/sqlcipher)** out-of-the-box – you just need to link against `libsqlcipher` (note: this has only been tested on MacOS but should work across platforms):
 
-| What you need | How to do it |
-|---------------|--------------|
-| **1. Install SQLCipher** | macOS: `brew install sqlcipher`  •  Ubuntu: `apt install sqlcipher libsqlcipher-dev`  •  Windows: grab the pre-built DLLs |
-| **2. Tell Odin you want SQLCipher** | `odin build . -define:SQLITE3_USE_SQLCIPHER=true -define:SQLITE3_DYNAMIC_LIB=true -define:SQLITE3_SYSTEM_LIB=true` |
+```sh
+odin build . -define:SQLITE3_USE_SQLCIPHER=true
+```
 
+*Note: Other build flags remain the same. You will need to compile sqlcipher or install from your OS's package manager.*
 
 ### 🔐  SQLCipher-only functions
 
@@ -260,6 +260,8 @@ All four return the usual SQLite result code – `SQLITE_OK` on success, or `SQL
 ### Minimal example
 
 ```odin
+import "core:c"
+
 main :: proc() {
     db: ^sqlite.Connection = nil
 
@@ -267,18 +269,20 @@ main :: proc() {
     if sqlite.open("./encrypted.sqlite", &db) != .Ok {
         panic("open failed")
     }
-    defer sqlite.close(db_handle)
+    defer sqlite.close(db)
 
     // Provide the secret for the database. You MUST do this before using it.
-    secret : cstring = "Tr0ub4dor&3";
-    if sqlite.key(db, cast(rawptr)secret.data, cast(c.int)len(secret)) != .Ok {
-        panic("wrong key?");
+    secret := "Tr0ub4dor&3";
+    if sqlite.key(db, raw_data(secret), cast(c.int)len(secret)) != .Ok {
+        // Handle error
     }
 
+    // ...Everything else is the same as using SQLite...
+
     // Change the secret for the database.
-    new_secret : cstring = "CorrectHorseBatteryStaple";
-    if sqlite.rekey(db, cast(rawptr)new_secret.data, cast(c.int)len(new_secret)) != .Ok {
-        panic("rekey failed");
+    new_secret := "CorrectHorseBatteryStaple";
+    if sqlite.rekey(db, raw_data(new_secret), cast(c.int)len(new_secret)) != 0 {
+        // Handle error
     }
 }
 ```

--- a/sqlite.odin
+++ b/sqlite.odin
@@ -11,47 +11,97 @@ Blob :: rawptr
 USE_DYNAMIC_LIB :: #config(SQLITE3_DYNAMIC_LIB, false)
 @(private)
 USE_SYSTEM_LIB :: #config(SQLITE3_SYSTEM_LIB, false)
+@(private)
+USE_SQLCIPHER :: #config(SQLITE3_USE_SQLCIPHER, false)
 
 when ODIN_OS == .Windows {
 	when USE_SYSTEM_LIB {
 		when USE_DYNAMIC_LIB {
-			foreign import sqlite "system:libsqlite3.dll"
+			when USE_SQLCIPHER {
+				foreign import sqlite "system:libsqlcipher.dll"
+			} else {
+				foreign import sqlite "system:libsqlite3.dll"
+			}
 		} else {
-			foreign import sqlite "system:libsqlite3.lib"
+			when USE_SQLCIPHER {
+				foreign import sqlite "system:libsqlcipher.lib"
+			} else {
+				foreign import sqlite "system:libsqlite3.lib"
+			}
 		}
 	} else {
 		when USE_DYNAMIC_LIB {
-			foreign import sqlite "libsqlite3.dll"
+			when USE_SQLCIPHER {
+				foreign import sqlite "libsqlcipher.dll"
+			} else {
+				foreign import sqlite "libsqlite3.dll"
+			}
 		} else {
-			foreign import sqlite "libsqlite3.lib"
+			when USE_SQLCIPHER {
+				foreign import sqlite "libsqlcipher.lib"
+			} else {
+				foreign import sqlite "libsqlite3.lib"
+			}
 		}
 	}
 } else when ODIN_OS == .Darwin {
 	when USE_SYSTEM_LIB {
 		when USE_DYNAMIC_LIB {
-			foreign import sqlite "system:libsqlite3.dylib"
+			when USE_SQLCIPHER {
+				foreign import sqlite "system:libsqlcipher.dylib"
+			} else {
+				foreign import sqlite "system:libsqlite3.dylib"
+			}
 		} else {
-			foreign import sqlite "system:libsqlite3.a"
+			when USE_SQLCIPHER {
+				foreign import sqlite "system:libsqlcipher.a"
+			} else {
+				foreign import sqlite "system:libsqlite3.a"
+			}
 		}
 	} else {
 		when USE_DYNAMIC_LIB {
-			foreign import sqlite "libsqlite3.dylib"
+			when USE_SQLCIPHER {
+				foreign import sqlite "libsqlcipher.dylib"
+			} else {
+				foreign import sqlite "libsqlite3.dylib"
+			}
 		} else {
-			foreign import sqlite "libsqlite3.a"
+			when USE_SQLCIPHER {
+				foreign import sqlite "libsqlcipher.a"
+			} else {
+				foreign import sqlite "libsqlite3.a"
+			}
 		}
 	}
 } else when ODIN_OS == .Linux {
 	when USE_SYSTEM_LIB {
 		when USE_DYNAMIC_LIB {
-			foreign import sqlite "system:libsqlite3.so"
+			when USE_SQLCIPHER {
+				foreign import sqlite "system:libsqlcipher.so"
+			} else {
+				foreign import sqlite "system:libsqlite3.so"
+			}
 		} else {
-			foreign import sqlite "system:libsqlite3.a"
+			when USE_SQLCIPHER {
+				foreign import sqlite "system:libsqlcipher.a"
+			} else {
+				foreign import sqlite "system:libsqlite3.a"
+			}
 		}
 	} else {
 		when USE_DYNAMIC_LIB {
-			foreign import sqlite "libsqlite3.so"
+			when USE_SQLCIPHER {
+				foreign import sqlite "libsqlcipher.so"
+			} else {
+				foreign import sqlite "libsqlite3.so"
+			}
 		} else {
-			foreign import sqlite "libsqlite3.a"
+			when USE_SQLCIPHER {
+				foreign import sqlite "libsqlcipher.a"
+			} else {
+				foreign import sqlite "libsqlite3.a"
+			}
 		}
 	}
 }
@@ -279,4 +329,12 @@ foreign sqlite {
 	config :: proc "c" (option: Config_Option) -> Result_Code ---
 	sql :: proc "c" (statement: ^Statement) -> cstring ---
 	expanded_sql :: proc "c" (statement: ^Statement) -> cstring ---
+
+	// Export SQLCipher-specific functions conditionally.
+	when USE_SQLCIPHER {
+		key :: proc "c" (db: ^Connection, key: rawptr, nKey: c.int) -> c.int ---
+		key_v2 :: proc "c" (db: ^Connection, zDbName: cstring, key: rawptr, nKey: c.int) -> c.int ---
+		rekey :: proc "c" (db: ^Connection, key: rawptr, nKey: c.int) -> c.int ---
+		rekey_v2 :: proc "c" (db: ^Connection, zDbName: cstring, key: rawptr, nKey: c.int) -> c.int ---
+	}
 }


### PR DESCRIPTION
## Overview

This pull request:

- Adds a new `-define` flag `SQLITE3_USE_SQLCIPHER`
  - If the define flag is set, it will look for `libsqlcipher.{ext}` instead of `libsqlite3.{ext}`
  - If the define flag is set, it will expose `key`, `key_v2`, `rekey` and `rekey_v2` (for encryption password management)
- Adds documentation for how to use it

## Testing

I ran the following quick & hacky test script to ensure it all works:

```odin
package testbed

// NOTE:  the module alias is **sqlite** but we import it from the
//        *extern* collection where you added the sub-module.
import sqlite "../libs/odin-sqlite3"

import "base:runtime"
import "core:c"
import "core:fmt"
import "core:mem"
import "core:strings"

main :: proc() {
	db: ^sqlite.Connection
	if rc := sqlite.open("encrypted.db", &db); rc != .Ok {
		fmt.printfln("failed to open DB, rc = {}", rc)
		return
	}
	defer sqlite.close(db)

	secret := "CorrectHorseBatteryStaple"

	if sqlite.key(db, raw_data(secret), cast(c.int)len(secret)) != 0 {
		fmt.println("wrong key (or SQLCipher not linked)")
		return
	}

	sql: cstring = "CREATE TABLE IF NOT EXISTS demo (id  INTEGER PRIMARY KEY, msg TEXT); INSERT INTO demo(msg) VALUES ('hello from SQLCipher');"

	err_msg: cstring
	if sqlite.exec(db, sql, nil, nil, &err_msg) != .Ok {
		fmt.printfln("SQL error: {}", err_msg)
		sqlite.free(cast(rawptr)err_msg)
		return
	}

	stmt: ^sqlite.Statement = nil
	select_sql: cstring = "SELECT id, msg FROM demo;"

	if rc := sqlite.prepare_v2(db, select_sql, -1, &stmt, nil); rc != .Ok {
		fmt.printfln("prepare failed (rc={})", rc)
		return
	}
	defer sqlite.finalize(stmt)

	fmt.println("\nrows from `demo`:")
	for {
		rc := sqlite.step(stmt)
		if rc == .Row {
			id := sqlite.column_int64(stmt, 0)
			text := sqlite.column_text(stmt, 1)
			fmt.printfln("  id={}  msg=\"{}\"", id, text)
		} else if rc == .Done {
			break
		} else {
			fmt.printfln("step error (rc={})", rc)
			return
		}
	}

	new_secret := "CorrectBatteryHorseStaple"
	if sqlite.rekey(db, cast(rawptr)raw_data(new_secret), cast(c.int)len(new_secret)) != 0 {
		fmt.println("rekey failed")
		return
	}

	fmt.println("✅ encrypted database works")
}
```

Output:

```sh
% odin run src -define:SQLITE3_DYNAMIC_LIB=true -define:SQLITE3_USE_SQLCIPHER=true                                                                                                            !1586

rows from `demo`:
  id=1  msg="hello from SQLCipher"
✅ encrypted database works
```

Running it a 2nd time fails because the passphrase has changed. If anyone else could test this on Windows/Linux, that'd be great:

```sh
% odin run src -define:SQLITE3_DYNAMIC_LIB=true -define:SQLITE3_USE_SQLCIPHER=true                                                                                                            !1586

SQL error: file is not a database
```

## Limitations

I can only test this on MacOS on Apple Silicon.