### PR TITLE
simple fix to Destructor callback in sqlite.odin

### DIFF
--- a/sqlite.odin
+++ b/sqlite.odin
@@ -144,7 +144,7 @@ Destructor_Behavior :: enum (int) {
 }
 
 Destructor :: struct #raw_union {
-	callback:  proc(it: rawptr),
+	callback:  proc"c"(it: rawptr),
 	behaviour: Destructor_Behavior,
 }
 


### PR DESCRIPTION
> [!Warning]
> I only tested this on windows, but I'm pretty sure this is not a windows specific bug.

Since the `Destructor.callback`  gets called from C code it should be `proc "c" (it: rawptr)` instead of simply a `proc(it: rawptr)`

Minimal code example of where the error occurs:

```odin

import "core:fmt"
import "core:strings"
import sqlite "custom:odin-sqlite3"

main :: proc() {
    db: ^sqlite.Connection
    stmt: ^sqlite.Statement
    sql: cstring = "SELECT * FROM Table where Name=?"
    
    err := sqlite.open("example.db", &db)
    fmt.println(err)
    
    err = sqlite.prepare_v2(db, sql, cast(i32)len(sql), &stmt, nil)
    fmt.println(err)

    value := strings.clone_to_cstring("Testing")
    free_value :: proc(it: rawptr) {
        delete(cast(cstring)it)
    }
    err = sqlite.bind_text(stmt, 1, value, cast(i32)len(value), { callback = free_value })
    fmt.println(err)
    
    err = sqlite.finalize(stmt)
    fmt.println(err)
}

```

This crashes before finishing execution.


Simply changing the `Destructor.callback` to `proc"c"(it: rawptr)` solves the issue with minimal changes to the code.

```odin

import "core:fmt"
import "core:strings"
import "base:runtime"
import sqlite "custom:odin-sqlite3"

main :: proc() {
    db: ^sqlite.Connection
    stmt: ^sqlite.Statement
    sql: cstring = "SELECT * FROM Table where Name=?"
    
    err := sqlite.open("example.db", &db)
    fmt.println(err)
    
    err = sqlite.prepare_v2(db, sql, cast(i32)len(sql), &stmt, nil)
    fmt.println(err)

    value := strings.clone_to_cstring("Testing")
    free_value :: proc"c"(it: rawptr) {
        context = runtime.default_context()
        delete(cast(cstring)it)
    }
    err = sqlite.bind_text(stmt, 1, value, cast(i32)len(value), { callback = free_value })
    fmt.println(err)
    
    err = sqlite.finalize(stmt)
    fmt.println(err)
}

```